### PR TITLE
MK-268

### DIFF
--- a/drupal/modules/obiba_mica/obiba_mica_network/templates/obiba_mica_network-detail.tpl.php
+++ b/drupal/modules/obiba_mica/obiba_mica_network/templates/obiba_mica_network-detail.tpl.php
@@ -6,9 +6,13 @@
   <?php if (!empty($network_dto->description)): ?>
     <p class="md-top-margin">
       <?php if (!empty($network_dto->logo->id)): ?>
+        <a
+          href="<?php print obiba_mica_commons_safe_expose_server_url($network_dto->id, $network_dto->logo, 'network') ?>"
+          class="fancybox-button">
         <img
           src="<?php print obiba_mica_commons_safe_expose_server_url($network_dto->id, $network_dto->logo, 'network') ?>"
           class="imageThumb">
+        </a>
       <?php endif; ?>
       <?php print obiba_mica_commons_markdown(obiba_mica_commons_get_localized_field($network_dto, 'description')); ?>
     </p>

--- a/drupal/modules/obiba_mica/obiba_mica_study/templates/obiba_mica_study-detail.tpl.php
+++ b/drupal/modules/obiba_mica/obiba_mica_study/templates/obiba_mica_study-detail.tpl.php
@@ -7,9 +7,14 @@
 <div>
   <p class="md-top-margin">
     <?php if (!empty($study_dto->logo->id)): ?>
-      <img src="<?php print obiba_mica_commons_safe_expose_server_url($study_dto->id, $study_dto->logo, 'study') ?>"
-        class="imageThumb">
+      <a href="<?php print obiba_mica_commons_safe_expose_server_url($study_dto->id, $study_dto->logo, 'study') ?>"
+        class="fancybox-button">
+        <img
+          src="<?php print obiba_mica_commons_safe_expose_server_url($study_dto->id, $study_dto->logo, 'study') ?>"
+          class="imageThumb">
+      </a>
     <?php endif; ?>
+
     <?php print obiba_mica_commons_markdown(obiba_mica_commons_get_localized_field($study_dto, 'objectives')); ?>
   </p>
   <?php if (!empty($datasets) && !empty($datasets['total_variable_nbr'])): ?>
@@ -395,7 +400,7 @@
                 print 'active';
               } ?>"
                 id="population-<?php print $key; ?>">
-              <?php print $population['html']; ?>
+                <?php print $population['html']; ?>
               </div>
             <?php endforeach ?>
           </div>


### PR DESCRIPTION
Logo width is too restrictive
Using fancyBox system can increase user experience, so it can enlarge images by clicking on it, and by the way, we can also add images in our content that have the same behavior
If the fancyBox plugin is not loaded, the images will be opened in a new page in original sizes