### PR TITLE
Makefile release performing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 mica_current_tag = 1.0.0
-mica_modules_version=1.0.x
+mica_branch_version=1.0.x
 drupal_version = 7.32
-mica_version=$(drupal_version)-$(mica_modules_version)
+mica_version=$(drupal_version)-$(mica_current_tag)
 drupal_org_mica=git.drupal.org:project/obiba_mica.git
 obiba-progressbar-version=1.0.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-mica_version=1.0-dev
-mica_branch=7.x-1.x
+mica_current_tag = 1.0.0
+mica_modules_version=1.0.x
+drupal_version = 7.32
+mica_version=$(drupal_version)-$(mica_modules_version)
 drupal_org_mica=git.drupal.org:project/obiba_mica.git
 obiba-progressbar-version=1.0.0
-
-drupal_version = 7.32
 
 #
 # Mysql db access
@@ -21,6 +21,8 @@ help:
 	@echo "  all          : Clean & setup Drupal with a symlink to Mica modules in target directory and import drupal.sql"
 	@echo "  setup-drupal : Setup Drupal with Mica modules in target directory"
 	@echo
+
+include make-perform-release.mk
 
 all: clean setup-drupal www import-sql settings bootstrap enable-mica enable-obiba-auth devel less-css jquery_update datatables obiba-progressbar cc
 
@@ -123,38 +125,3 @@ obiba-progressbar:
 
 cc:
 	cd target/drupal && drush cc all
-
-#
-# Push to Drupal.org
-#
-git-push-mica:
-	$(call clear-version-info,drupal/modules,obiba_mica) && \
-	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_study) && \
-	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_commons) && \
-	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_network) && \
-	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_model) && \
-	$(call git-prepare,$(drupal_org_mica),obiba_mica,$(mica_branch)) . && \
-	cp -r drupal/modules/obiba_mica/* target/drupal.org/obiba_mica && \
-	$(call git-finish,obiba_mica,$(mica_branch))
-
-clear-version-info = sed -i "/^version/d" $(1)/$2/$2.info && \
-	sed -i "/^project/d" $(1)/$2/$2.info && \
-	sed -i "/^datestamp/d" $(1)/$2/$2.info && \
-	sed -i "/Information added by obiba.org packaging script/d" $(1)/$2/$2.info
-
-git-prepare = rm -rf target/drupal.org/$(2) && \
-	mkdir -p target/drupal.org && \
-	echo "Enter Drupal username?" && \
-	read git_username && \
-	git clone --recursive --branch $(branch) $$git_username@git.drupal.org:project/$(2) target/drupal.org/$(2) && \
-	cd target/drupal.org/$(2) && \
-	git rm -rf * && \
-	cd ../../..
-
-git-finish = cd target/drupal.org/$(1) && \
-	git add . && \
-	git status && \
-	echo "Enter a message for this commit?" && \
-	read git_commit_msg && \
-	git commit -m "$$git_commit_msg" && \
-	git log

--- a/drupal/modules/obiba_mica/obiba_mica.info
+++ b/drupal/modules/obiba_mica/obiba_mica.info
@@ -18,7 +18,7 @@ dependencies[] = obiba_mica_search
 dependencies[] = obiba_mica_dataset
 dependencies[] = obiba_mica_network
 
-; Information added by obiba.org packaging script on 
-version = 7.32-1.0.x
+; Information added by obiba.org packaging script on Wed, 15 Apr 2015 18:06:58 -0400
+version = 7.32-1.0.0
 project = obiba_mica
-datestamp = 1429134570
+datestamp = 1429135618

--- a/drupal/modules/obiba_mica/obiba_mica.info
+++ b/drupal/modules/obiba_mica/obiba_mica.info
@@ -18,4 +18,7 @@ dependencies[] = obiba_mica_search
 dependencies[] = obiba_mica_dataset
 dependencies[] = obiba_mica_network
 
-scripts[] = js/obiba-mica-progressbar-controller.js
+; Information added by obiba.org packaging script on 
+version = 7.32-1.0.x
+project = obiba_mica
+datestamp = 1429134570

--- a/drupal/modules/obiba_mica/obiba_mica_commons/obiba_mica_commons.info
+++ b/drupal/modules/obiba_mica/obiba_mica_commons/obiba_mica_commons.info
@@ -5,7 +5,7 @@ core = 7.x
 
 dependencies[] = http_client
 
-; Information added by obiba.org packaging script on 
-version = 7.32-1.0.x
+; Information added by obiba.org packaging script on Wed, 15 Apr 2015 18:06:58 -0400
+version = 7.32-1.0.0
 project = obiba_mica_commons
-datestamp = 1429134570
+datestamp = 1429135618

--- a/drupal/modules/obiba_mica/obiba_mica_commons/obiba_mica_commons.info
+++ b/drupal/modules/obiba_mica/obiba_mica_commons/obiba_mica_commons.info
@@ -5,4 +5,7 @@ core = 7.x
 
 dependencies[] = http_client
 
-files[] = includes/obiba_mica.inc
+; Information added by obiba.org packaging script on 
+version = 7.32-1.0.x
+project = obiba_mica_commons
+datestamp = 1429134570

--- a/drupal/modules/obiba_mica/obiba_mica_dataset/obiba_mica_dataset.info
+++ b/drupal/modules/obiba_mica/obiba_mica_dataset/obiba_mica_dataset.info
@@ -5,7 +5,7 @@ core = 7.x
 dependencies[] = obiba_mica_commons
 dependencies[] = obiba_mica_model
 dependencies[] = obiba_mica_study
-; Information added by obiba.org packaging script on 
-version = 7.32-1.0.x
+; Information added by obiba.org packaging script on Wed, 15 Apr 2015 18:06:58 -0400
+version = 7.32-1.0.0
 project = obiba_mica_dataset
-datestamp = 1429134570
+datestamp = 1429135618

--- a/drupal/modules/obiba_mica/obiba_mica_dataset/obiba_mica_dataset.info
+++ b/drupal/modules/obiba_mica/obiba_mica_dataset/obiba_mica_dataset.info
@@ -5,3 +5,7 @@ core = 7.x
 dependencies[] = obiba_mica_commons
 dependencies[] = obiba_mica_model
 dependencies[] = obiba_mica_study
+; Information added by obiba.org packaging script on 
+version = 7.32-1.0.x
+project = obiba_mica_dataset
+datestamp = 1429134570

--- a/drupal/modules/obiba_mica/obiba_mica_model/obiba_mica_model.info
+++ b/drupal/modules/obiba_mica/obiba_mica_model/obiba_mica_model.info
@@ -3,4 +3,7 @@ description = "Mica Client -- Model"
 package = Obiba
 core = 7.x
 
-dependencies[] = obiba_protobuf
+; Information added by obiba.org packaging script on 
+version = 7.32-1.0.x
+project = obiba_mica_model
+datestamp = 1429134570

--- a/drupal/modules/obiba_mica/obiba_mica_model/obiba_mica_model.info
+++ b/drupal/modules/obiba_mica/obiba_mica_model/obiba_mica_model.info
@@ -3,7 +3,7 @@ description = "Mica Client -- Model"
 package = Obiba
 core = 7.x
 
-; Information added by obiba.org packaging script on 
-version = 7.32-1.0.x
+; Information added by obiba.org packaging script on Wed, 15 Apr 2015 18:06:58 -0400
+version = 7.32-1.0.0
 project = obiba_mica_model
-datestamp = 1429134570
+datestamp = 1429135618

--- a/drupal/modules/obiba_mica/obiba_mica_network/obiba_mica_network.info
+++ b/drupal/modules/obiba_mica/obiba_mica_network/obiba_mica_network.info
@@ -5,3 +5,7 @@ core = 7.x
 dependencies[] = obiba_mica_commons
 dependencies[] = obiba_mica_model
 dependencies[] = obiba_mica_study
+; Information added by obiba.org packaging script on 
+version = 7.32-1.0.x
+project = obiba_mica_network
+datestamp = 1429134570

--- a/drupal/modules/obiba_mica/obiba_mica_network/obiba_mica_network.info
+++ b/drupal/modules/obiba_mica/obiba_mica_network/obiba_mica_network.info
@@ -5,7 +5,7 @@ core = 7.x
 dependencies[] = obiba_mica_commons
 dependencies[] = obiba_mica_model
 dependencies[] = obiba_mica_study
-; Information added by obiba.org packaging script on 
-version = 7.32-1.0.x
+; Information added by obiba.org packaging script on Wed, 15 Apr 2015 18:06:58 -0400
+version = 7.32-1.0.0
 project = obiba_mica_network
-datestamp = 1429134570
+datestamp = 1429135618

--- a/drupal/modules/obiba_mica/obiba_mica_search/obiba_mica_search.info
+++ b/drupal/modules/obiba_mica/obiba_mica_search/obiba_mica_search.info
@@ -8,7 +8,7 @@ core = 7.x
 dependencies[] = obiba_mica_commons
 dependencies[] = obiba_mica_model
 dependencies[] = charts_google
-; Information added by obiba.org packaging script on 
-version = 7.32-1.0.x
+; Information added by obiba.org packaging script on Wed, 15 Apr 2015 18:06:58 -0400
+version = 7.32-1.0.0
 project = obiba_mica_search
-datestamp = 1429134570
+datestamp = 1429135618

--- a/drupal/modules/obiba_mica/obiba_mica_search/obiba_mica_search.info
+++ b/drupal/modules/obiba_mica/obiba_mica_search/obiba_mica_search.info
@@ -8,3 +8,7 @@ core = 7.x
 dependencies[] = obiba_mica_commons
 dependencies[] = obiba_mica_model
 dependencies[] = charts_google
+; Information added by obiba.org packaging script on 
+version = 7.32-1.0.x
+project = obiba_mica_search
+datestamp = 1429134570

--- a/drupal/modules/obiba_mica/obiba_mica_study/obiba_mica_study.info
+++ b/drupal/modules/obiba_mica/obiba_mica_study/obiba_mica_study.info
@@ -7,3 +7,7 @@ dependencies[] = obiba_mica_commons
 dependencies[] = obiba_mica_model
 
 files[] = includes/obiba_mica_study_resource.inc
+; Information added by obiba.org packaging script on 
+version = 7.32-1.0.x
+project = obiba_mica_study
+datestamp = 1429134570

--- a/drupal/modules/obiba_mica/obiba_mica_study/obiba_mica_study.info
+++ b/drupal/modules/obiba_mica/obiba_mica_study/obiba_mica_study.info
@@ -7,7 +7,7 @@ dependencies[] = obiba_mica_commons
 dependencies[] = obiba_mica_model
 
 files[] = includes/obiba_mica_study_resource.inc
-; Information added by obiba.org packaging script on 
-version = 7.32-1.0.x
+; Information added by obiba.org packaging script on Wed, 15 Apr 2015 18:06:58 -0400
+version = 7.32-1.0.0
 project = obiba_mica_study
-datestamp = 1429134570
+datestamp = 1429135618

--- a/drupal/themes/obiba_bootstrap/obiba_bootstrap.info
+++ b/drupal/themes/obiba_bootstrap/obiba_bootstrap.info
@@ -91,3 +91,7 @@ scripts[] = js/obiba-bootstrap-progressbar-controller.js
 ; --------------
 settings[bootstrap_region_well-facets] = 'well'
 
+; Information added by obiba.org packaging script on 
+version = 7.32-1.0.x
+project = obiba_bootstrap
+datestamp = 1429134570

--- a/drupal/themes/obiba_bootstrap/obiba_bootstrap.info
+++ b/drupal/themes/obiba_bootstrap/obiba_bootstrap.info
@@ -91,7 +91,7 @@ scripts[] = js/obiba-bootstrap-progressbar-controller.js
 ; --------------
 settings[bootstrap_region_well-facets] = 'well'
 
-; Information added by obiba.org packaging script on 
-version = 7.32-1.0.x
+; Information added by obiba.org packaging script on Wed, 15 Apr 2015 18:06:58 -0400
+version = 7.32-1.0.0
 project = obiba_bootstrap
-datestamp = 1429134570
+datestamp = 1429135618

--- a/make-perform-release.mk
+++ b/make-perform-release.mk
@@ -1,0 +1,35 @@
+#
+#Seed versions of current release
+#
+#
+include make-seed-versions.mk
+
+#
+#
+#Push to GitHub
+#
+#
+git-mica-release: inject-version-info github-release
+
+#
+# Push to Drupal.org
+#
+git-push-mica:
+	$(call clear-version-info,drupal/modules,obiba_mica) && \
+	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_study) && \
+	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_commons) && \
+	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_network) && \
+	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_model) && \
+	$(call git-prepare,$(drupal_org_mica),obiba_mica,$(mica_branch)) . && \
+	cp -r drupal/modules/obiba_mica/* target/drupal.org/obiba_mica && \
+	$(call git-finish,obiba_mica,$(mica_branch))
+
+clear-version-info = sed -i "/^version/d" $(1)/$2/$2.info && \
+	sed -i "/^project/d" $(1)/$2/$2.info && \
+	sed -i "/^datestamp/d" $(1)/$2/$2.info && \
+	sed -i "/Information added by obiba.org packaging script/d" $(1)/$2/$2.info
+
+github-release = echo "Enter a message for this tag push release?" && \
+	read git_push_msg && \
+	git tag -a $(mica_current_tag) -m "$$git_push_msg" && \
+	git push upstream/$(mica_current_tag) && \

--- a/make-perform-release.mk
+++ b/make-perform-release.mk
@@ -14,22 +14,9 @@ git-mica-release: inject-version-info github-release
 #
 # Push to Drupal.org
 #
-git-push-mica:
-	$(call clear-version-info,drupal/modules,obiba_mica) && \
-	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_study) && \
-	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_commons) && \
-	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_network) && \
-	$(call clear-version-info,drupal/modules/obiba_mica,obiba_mica_model) && \
-	$(call git-prepare,$(drupal_org_mica),obiba_mica,$(mica_branch)) . && \
-	cp -r drupal/modules/obiba_mica/* target/drupal.org/obiba_mica && \
-	$(call git-finish,obiba_mica,$(mica_branch))
 
-clear-version-info = sed -i "/^version/d" $(1)/$2/$2.info && \
-	sed -i "/^project/d" $(1)/$2/$2.info && \
-	sed -i "/^datestamp/d" $(1)/$2/$2.info && \
-	sed -i "/Information added by obiba.org packaging script/d" $(1)/$2/$2.info
-
-github-release = echo "Enter a message for this tag push release?" && \
+github-release:
+	echo "Enter a message for this tag push release?" && \
 	read git_push_msg && \
 	git tag -a $(mica_current_tag) -m "$$git_push_msg" && \
-	git push upstream/$(mica_current_tag) && \
+	git push upstream $(mica_current_tag)

--- a/make-perform-release.mk
+++ b/make-perform-release.mk
@@ -16,6 +16,7 @@ git-mica-release: inject-version-info github-release
 #
 
 github-release:
+	git checkout mica-drupal7-client-$(mica_branch_version) && \
 	echo "Enter a message for this tag push release?" && \
 	read git_push_msg && \
 	git tag -a $(mica_current_tag) -m "$$git_push_msg" && \

--- a/make-seed-versions.mk
+++ b/make-seed-versions.mk
@@ -5,7 +5,6 @@
 datestamp=$(shell date +%s)
 release_date=$(shell date -R)
 
-
 inject-version-info:
 	$(call inject-version-info,modules/,obiba_mica,$(mica_version))
 	$(call inject-version-info,modules/obiba_mica,obiba_mica_commons,$(mica_version))
@@ -16,10 +15,6 @@ inject-version-info:
 	$(call inject-version-info,modules/obiba_mica,obiba_mica_study,$(mica_version))
 	$(call inject-version-info,themes/,obiba_bootstrap,$(mica_version)) && \
 	git commit -a -m "version updated to $(mica_current_tag)"
-
-
-
-
 
 # inject-version-info-version function: remove (if present) and add specified version number to project info file
 inject-version-info = cd drupal/$(1) && \

--- a/make-seed-versions.mk
+++ b/make-seed-versions.mk
@@ -1,0 +1,32 @@
+#
+#
+#
+#
+datestamp=$(shell date +%s)
+
+
+
+inject-version-info:
+	$(call inject-version-info,modules/,obiba_mica,$(mica_version))
+	$(call inject-version-info,modules/obiba_mica,obiba_mica_commons,$(mica_version))
+	$(call inject-version-info,modules/obiba_mica,obiba_mica_dataset,$(mica_version))
+	$(call inject-version-info,modules/obiba_mica,obiba_mica_model,$(mica_version))
+	$(call inject-version-info,modules/obiba_mica,obiba_mica_network,$(mica_version))
+	$(call inject-version-info,modules/obiba_mica,obiba_mica_search,$(mica_version))
+	$(call inject-version-info,modules/obiba_mica,obiba_mica_study,$(mica_version))
+	$(call inject-version-info,themes/,obiba_bootstrap,$(mica_version))
+
+
+
+
+
+# inject-version-info-version function: remove (if present) and add specified version number to project info file
+inject-version-info = cd drupal/$(1) && \
+	sed -i "/^version/d" $2/$2.info && \
+	sed -i "/^project/d" $2/$2.info && \
+	sed -i "/^datestamp/d" $2/$2.info && \
+	sed -i "/Information added by obiba.org packaging script/d" $2/$2.info && \
+	echo "; Information added by obiba.org packaging script on $(deb_date)" >> $2/$2.info && \
+	echo "version = $(3)" >> $2/$2.info && \
+	echo "project = $2" >> $2/$2.info && \
+	echo "datestamp = $(datestamp)" >> $2/$2.info

--- a/make-seed-versions.mk
+++ b/make-seed-versions.mk
@@ -14,7 +14,8 @@ inject-version-info:
 	$(call inject-version-info,modules/obiba_mica,obiba_mica_network,$(mica_version))
 	$(call inject-version-info,modules/obiba_mica,obiba_mica_search,$(mica_version))
 	$(call inject-version-info,modules/obiba_mica,obiba_mica_study,$(mica_version))
-	$(call inject-version-info,themes/,obiba_bootstrap,$(mica_version))
+	$(call inject-version-info,themes/,obiba_bootstrap,$(mica_version)) && \
+	git commit -a -m "version updated to $(mica_current_tag)"
 
 
 

--- a/make-seed-versions.mk
+++ b/make-seed-versions.mk
@@ -3,7 +3,7 @@
 #
 #
 datestamp=$(shell date +%s)
-
+release_date=$(shell date -R)
 
 
 inject-version-info:
@@ -27,7 +27,7 @@ inject-version-info = cd drupal/$(1) && \
 	sed -i "/^project/d" $2/$2.info && \
 	sed -i "/^datestamp/d" $2/$2.info && \
 	sed -i "/Information added by obiba.org packaging script/d" $2/$2.info && \
-	echo "; Information added by obiba.org packaging script on $(deb_date)" >> $2/$2.info && \
+	echo "; Information added by obiba.org packaging script on $(release_date)" >> $2/$2.info && \
 	echo "version = $(3)" >> $2/$2.info && \
 	echo "project = $2" >> $2/$2.info && \
 	echo "datestamp = $(datestamp)" >> $2/$2.info


### PR DESCRIPTION
Step required to release a new version: 
-  Before performing a release we need to merge the mica-drupal7-client-x.x.x branch with master
-  Edit Makefile to increment the 'mica_current_tag' to the new desired tag version 
-  Run 'make git-mica-release' to perform the release

'make git-mica-release'  performs the following operations required for a release  :  
- Updates '.info' files with the proper version  
- Checks out to mica-drupal7-client-x.x.x branch
- Creates a tag from mica-drupal7-client-x.x.x branch
- Pushes to uptream the released tag

